### PR TITLE
Add option to ignore Template Name header

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,8 @@ function setDefaultOptions (options) {
       { name: 'esc_html__' },
       { name: 'esc_html_e' },
       { name: 'esc_html_x', context: 2 }
-    ]
+    ],
+    ignoreTemplateNameHeader: false
   };
 
   if (options.headers === false) {

--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,10 @@ wpPot({
   Description: Write pot-file to disk. The function always returns the contents as well.
   Type: `boolean`
   Default: `true`
+- `ignoreTemplateNameHeader`
+  Description: Do not extract `/* Template Name: String */` headers to POT file.
+  Type: `boolean`
+  Default: `false`
 
 
 ## Related

--- a/test/6-file-headers-test.js
+++ b/test/6-file-headers-test.js
@@ -48,4 +48,16 @@ describe('File Headers tests', () => {
 
     assert(testHelper.verifyLanguageBlock(potContents, false, fixturePath + ':3', 'Hello World', false, false));
   });
+
+  it('Skips reading template name headers if skipTemplateNameHeader option true', () => {
+    const fixturePath = 'test/fixtures/template-headers.php';
+
+    const potContents = wpPot({
+      src: fixturePath,
+      writeFile: false,
+      ignoreTemplateNameHeader: true
+    });
+
+    assert.strictEqual(testHelper.verifyLanguageBlock(potContents, false, fixturePath + ':3', 'Hello World', false, false), false);
+  });
 });

--- a/translation-parser.js
+++ b/translation-parser.js
@@ -349,7 +349,9 @@ class TranslationParser {
       this.parseFileHeader(['Plugin Name', 'Theme Name', 'Description', 'Author', 'Author URI', 'Plugin URI', 'Theme URI'], filecontent, filename);
     }
 
-    this.parseFileHeader(['Template Name'], filecontent, filename);
+    if (!this.options.ignoreTemplateNameHeader) {
+      this.parseFileHeader(['Template Name'], filecontent, filename);
+    }
 
     // Skip file if no translation functions is found
     const validFunctionsInFile = new RegExp(this.options.functionCalls.valid.join('|').replace('$', '\\$'));


### PR DESCRIPTION
Hey, as per https://github.com/wp-pot/wp-pot/issues/83 I've added an option to ignore Template Name headers, but keeping the default functionality as before.

Not sure if the test I've added is acceptable.