### PR TITLE
Enable parsing text in array key

### DIFF
--- a/test/7-edge-cases-test.js
+++ b/test/7-edge-cases-test.js
@@ -109,6 +109,10 @@ describe('Edge cases function tests', () => {
     assert(testHelper.verifyLanguageBlock(potContents, false, fixturePath + ':48', 'Text in true ternary statements', false, false));
     assert(testHelper.verifyLanguageBlock(potContents, false, fixturePath + ':49', 'Text in false ternary statements', false, false));
   });
+
+  it('should include text in array keys', () => {
+    assert(testHelper.verifyLanguageBlock(potContents, false, fixturePath + ':51', 'Translation is in an array key', false, false));
+  });
 });
 
 describe('Namespace edge cases', () => {

--- a/test/fixtures/edge-cases.php
+++ b/test/fixtures/edge-cases.php
@@ -47,3 +47,6 @@ $a = (new ClassName(__('Text in new class parameter', 'testdomain')))->function(
 
 echo ( $bool_flag ) ? esc_html__( 'Text in true ternary statements', 'testdomain' ) : '';
 echo ( $bool_flag ) ? '' : esc_html__( 'Text in false ternary statements', 'testdomain' );
+[
+	__( 'Translation is in an array key', 'testdomain' ) => 'Value',
+];

--- a/translation-parser.js
+++ b/translation-parser.js
@@ -311,6 +311,7 @@ class TranslationParser {
         'trueExpr',
         'falseExpr',
         'items',
+        'key',
         'left',
         'right',
         'value',


### PR DESCRIPTION
Hello @rasmusbe, 

Parsing is not enabled in array keys. This PR fixes this issue. 

