### PR TITLE
Added empty string test case

### DIFF
--- a/test/7-edge-cases-test.js
+++ b/test/7-edge-cases-test.js
@@ -41,6 +41,10 @@ describe('Edge cases function tests', () => {
     assert(testHelper.verifyLanguageBlock(potContents, false, fixturePath + ':8', '"\n"New\\n"\n"Line', false, false));
   });
 
+  it('should handle empty strings', () => {
+    assert(testHelper.verifyLanguageBlock(potContents, false, fixturePath + ':53', '', false, false));
+  });
+
   it('should handle plural methods with non-integer value as count', () => {
     assert(testHelper.verifyLanguageBlock(potContents, false, fixturePath + ':13', 'Singular string', 'Plural string', false));
     assert(testHelper.verifyLanguageBlock(potContents, false, fixturePath + ':14', 'Singular string', 'Plural string', false));

--- a/test/fixtures/edge-cases.php
+++ b/test/fixtures/edge-cases.php
@@ -50,3 +50,4 @@ echo ( $bool_flag ) ? '' : esc_html__( 'Text in false ternary statements', 'test
 [
 	__( 'Translation is in an array key', 'testdomain' ) => 'Value',
 ];
+__( '', 'testdomain' );

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -37,7 +37,7 @@ function verifyLanguageBlock (potContents, comment, fileinfo, msgid, plural, con
     }
 
     // Check if msgid is correct
-    if (msgid && block.indexOf('msgid "' + msgid + '"\n') === -1) {
+    if (block.indexOf('msgid "' + msgid + '"\n') === -1) {
       continue;
     }
 


### PR DESCRIPTION
Just adding the empty string test case.
I've also made an adjustment to the `verifyLanguageBlock` helper method but I'm not sure if it is the right path to go.

Related to:
https://github.com/wp-pot/wp-pot/issues/141