### PR TITLE
Handle duplicate minimal required headers

### DIFF
--- a/src/pot-maker.js
+++ b/src/pot-maker.js
@@ -136,14 +136,29 @@ class PotMaker {
   generatePot (translations) {
     const copyrightText = typeof this.options.copyrightText === 'function' ? this.options.copyrightText(this.options) : this.options.copyrightText;
 
+    let starting_headers = {
+      'Project-Id-Version': this.options.package,
+      'MIME-Version': '1.0',
+      'Content-Type': 'text/plain; charset=UTF-8',
+      'Content-Transfer-Encoding': '8bit',
+    };
+    if (this.options.headers && !PotMaker.isEmptyObject(this.options.headers)) {
+      for (const key of Object.keys(starting_headers)) {
+        if (typeof this.options.headers[key] !== 'undefined') {
+          starting_headers[key] = this.options.headers[key];
+          delete this.options.headers[key];
+        }
+      }
+    }
+
     let contents = (
       `${copyrightText}
 msgid ""
 msgstr ""
-"Project-Id-Version: ${this.options.package}\\n"
-"MIME-Version: 1.0\\n"
-"Content-Type: text/plain; charset=UTF-8\\n"
-"Content-Transfer-Encoding: 8bit\\n"\n`);
+"Project-Id-Version: ${starting_headers['Project-Id-Version']}\\n"
+"MIME-Version: ${starting_headers['MIME-Version']}\\n"
+"Content-Type: ${starting_headers['Content-Type']}\\n"
+"Content-Transfer-Encoding: ${starting_headers['Content-Transfer-Encoding']}\\n"\n`);
 
     if (this.options.headers && !PotMaker.isEmptyObject(this.options.headers)) {
       this.options.headers = this.sortObject(this.options.headers);

--- a/src/pot-maker.js
+++ b/src/pot-maker.js
@@ -136,16 +136,16 @@ class PotMaker {
   generatePot (translations) {
     const copyrightText = typeof this.options.copyrightText === 'function' ? this.options.copyrightText(this.options) : this.options.copyrightText;
 
-    let starting_headers = {
+    const startingHeaders = {
       'Project-Id-Version': this.options.package,
       'MIME-Version': '1.0',
       'Content-Type': 'text/plain; charset=UTF-8',
-      'Content-Transfer-Encoding': '8bit',
+      'Content-Transfer-Encoding': '8bit'
     };
     if (this.options.headers && !PotMaker.isEmptyObject(this.options.headers)) {
-      for (const key of Object.keys(starting_headers)) {
+      for (const key of Object.keys(startingHeaders)) {
         if (typeof this.options.headers[key] !== 'undefined') {
-          starting_headers[key] = this.options.headers[key];
+          startingHeaders[key] = this.options.headers[key];
           delete this.options.headers[key];
         }
       }
@@ -155,10 +155,10 @@ class PotMaker {
       `${copyrightText}
 msgid ""
 msgstr ""
-"Project-Id-Version: ${starting_headers['Project-Id-Version']}\\n"
-"MIME-Version: ${starting_headers['MIME-Version']}\\n"
-"Content-Type: ${starting_headers['Content-Type']}\\n"
-"Content-Transfer-Encoding: ${starting_headers['Content-Transfer-Encoding']}\\n"\n`);
+"Project-Id-Version: ${startingHeaders['Project-Id-Version']}\\n"
+"MIME-Version: ${startingHeaders['MIME-Version']}\\n"
+"Content-Type: ${startingHeaders['Content-Type']}\\n"
+"Content-Transfer-Encoding: ${startingHeaders['Content-Transfer-Encoding']}\\n"\n`);
 
     if (this.options.headers && !PotMaker.isEmptyObject(this.options.headers)) {
       this.options.headers = this.sortObject(this.options.headers);


### PR DESCRIPTION
Assuming these headers are required and should be placed in this order, this change:
1. Sets these headers first in the right order (optionally overwritten by `this.options.headers` values)
2. Removes them from the rest of the headers that might be set after that (preventing duplicates).

Fixes #243 