### PR TITLE
Auto-populate `POT-Creation-Date` header

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,10 @@ wpPot({
   Description: Gettext functions used for finding translations.
   Type: `object`
   Default: WordPress translation functions.
+- `includePOTCreationDate`
+  Description: Auto-populate the `POT-Creation-Date` header.
+  Type: `bool`
+  Default: true
 - `lastTranslator`
   Description: Name and email address of the last translator (ex: `John Doe <me@example.com>`).
   Type: `string`

--- a/src/index.js
+++ b/src/index.js
@@ -158,14 +158,14 @@ function setHeaders (options) {
   }
 
   if (!options.noCreationDate) {
-    let d = new Date();
-    let nowString = [
+    const d = new Date();
+    const nowString = [
       `${d.getUTCFullYear()}`,
-      `-${String(d.getUTCMonth()+1).padStart(2, '0')}`,
+      `-${String(d.getUTCMonth() + 1).padStart(2, '0')}`,
       `-${String(d.getUTCDate()).padStart(2, '0')}`,
       ` ${String(d.getUTCHours()).padStart(2, '0')}`,
       `:${String(d.getUTCMinutes()).padStart(2, '0')}`,
-      `+0000`
+      '+0000'
     ].join('');
     options.headers['POT-Creation-Date'] = nowString;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,7 @@ function setDefaultOptions (options) {
 # This file is distributed under the same license as the ${options.package} package.`;
     },
     defaultHeaders: true,
+    includePOTCreationDate: true,
     noFilePaths: false,
     writeFile: true,
     gettextFunctions: [
@@ -157,7 +158,7 @@ function setHeaders (options) {
     options.headers['Report-Msgid-Bugs-To'] = options.bugReport;
   }
 
-  if (!options.noCreationDate) {
+  if (options.includePOTCreationDate) {
     const d = new Date();
     const nowString = [
       `${d.getUTCFullYear()}`,

--- a/src/index.js
+++ b/src/index.js
@@ -157,6 +157,19 @@ function setHeaders (options) {
     options.headers['Report-Msgid-Bugs-To'] = options.bugReport;
   }
 
+  if (!options.noCreationDate) {
+    let d = new Date();
+    let nowString = [
+      `${d.getUTCFullYear()}`,
+      `-${String(d.getUTCMonth()+1).padStart(2, '0')}`,
+      `-${String(d.getUTCDate()).padStart(2, '0')}`,
+      ` ${String(d.getUTCHours()).padStart(2, '0')}`,
+      `:${String(d.getUTCMinutes()).padStart(2, '0')}`,
+      `+0000`
+    ].join('');
+    options.headers['POT-Creation-Date'] = nowString;
+  }
+
   if (options.lastTranslator) {
     options.headers['Last-Translator'] = options.lastTranslator;
   }


### PR DESCRIPTION
Includes `POT-Creation-Date` by default.

Can be disabled by setting `options.noCreationDate` to `true`.

Fixes #45