### PR TITLE
Dynamically select the parser based on the file type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,8 +70,7 @@ function setDefaultOptions (options) {
       { name: 'esc_html_e' },
       { name: 'esc_html_x', context: 2 }
     ],
-    ignoreTemplateNameHeader: false,
-    parser: 'php'
+    ignoreTemplateNameHeader: false
   };
 
   options = Object.assign({}, defaultOptions, options);
@@ -212,7 +211,11 @@ function wpPot (options) {
 
   // Parse files
   for (const file of files) {
-    const ext = getFileExtension(file);
+    let ext = options.parser;
+    if (typeof ext === 'undefined') {
+      ext = getFileExtension(file);
+    }
+    ext = ext.toLowerCase();
     if (typeof parsers[ext] === 'undefined') {
       continue;
     }


### PR DESCRIPTION
Currently only a single parser may be used during each run. This update looks at the extension of each file and dynamically selects the appropriate parser based on the file type. If a parser isn't available the file is skipped. A single parser can be selected to use for all files (overriding the dynamic parser selection) by setting the parser option.